### PR TITLE
feat(sftp): adding sftp support to the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom",
  "once_cell",
  "version_check",
@@ -305,6 +306,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -616,6 +620,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +718,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -1057,6 +1087,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "flurry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037030493fadfabb7b5638c2d665c0d2d2e393d8fc7aff27926524cf98efd8c0"
+dependencies = [
+ "ahash",
+ "num_cpus",
+ "parking_lot",
+ "seize",
 ]
 
 [[package]]
@@ -1964,6 +2006,7 @@ dependencies = [
  "ringbuffer",
  "russh",
  "russh-keys",
+ "russh-sftp",
  "schemars",
  "serde",
  "serde_json",
@@ -1979,6 +2022,7 @@ dependencies = [
  "tracing-error",
  "tracing-log",
  "tracing-subscriber",
+ "umask",
  "warp",
 ]
 
@@ -2262,6 +2306,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3154,6 +3208,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "russh-sftp"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee348efc4f41efcc5283e70ee9a04751561a0dca8b4c518b5434a96f2213148"
+dependencies = [
+ "async-trait",
+ "bitflags 2.6.0",
+ "bytes",
+ "chrono",
+ "flurry",
+ "log",
+ "serde",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,6 +3455,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "seize"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "semver"
@@ -3922,6 +3999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,6 +4295,15 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "umask"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9a46c2549e35c054e0ffe281a3a6ec0007793db4df106604d37ed3f4d73d1c"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ reqwest = { version = "0.12.7", features = ["json", "stream", "multipart"] }
 ringbuffer = "0.15.0"
 russh = "0.45.0"
 russh-keys = "0.45.0"
+russh-sftp = "2.0.3"
 schemars = { version = "0.8.21", features = ["chrono"] }
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.124"
@@ -74,6 +75,7 @@ tracing = "0.1.40"
 tracing-error = { version = "0.2.0", features = ["traced-error"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+umask = "2.1.0"
 warp = "0.3.7"
 
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You can:
 
 - Get a shell in running pods - just like you would with SSH normally.
 - Access the logs for running and exited containers in a pod.
+- `scp` files from pods. sftp clients work as well.
 
 ![demo](./assets/demo.gif)
 
@@ -45,13 +46,51 @@ You can:
 From this point, here's a few suggestions for things to check out:
 
 - Start a new pod. It'll show up in the dashboard immediately!
+
 - Exec into a pod. Select the pod you want and go to the `Shell` tab. You'll be
   able to pick the command to exec and then be shell'd into the pod directly.
+
 - Follow the logs. Logs for all containers in a pod are streamed to the `Logs`
   tab when you've selected a pod from the main list.
 
+- `scp` some files out of a container:
+
+  ```bash
+  scp -P 2222 me@localhost:/default/my-pod/etc/hosts /tmp
+  ```
+
 [cli-download]: https://github.com/grampelberg/kuberift/releases
 [k3d]: https://k3d.io
+
+## Interaction
+
+### SSH
+
+To get to the dashboard, you can run:
+
+```bash
+ssh anything@my-remote-host-or-ip -p 2222
+```
+
+As you're authenticated either via OpenID or public key, the username is not
+used.
+
+### SFTP
+
+The cluster is represented by a file tree:
+
+```bash
+/<namespace>/<pod-name>/<container-name>/<file-path>
+```
+
+For the `nginx` pod running in `default`, you would do something like:
+
+```bash
+scp -P 2222 me@localhost:/default/nginx/nginx/etc/hosts /tmp
+```
+
+It can be a little easier to navigate all this with an sftp client as that'll
+render the file tree natively for you.
 
 ## Deployment
 
@@ -241,6 +280,13 @@ the design decisions section for an explanation of what's happening there.
 - table_filter_total - Number of times a table was filtered.
 - widget_views_total - Number of times a widget was created by resource
   (container, pod) and type (cmd, log, yaml, ...).
+- requests_total - Number of requests that have come in by type (pty, sftp).
+- sftp_active_sessions - Total number of active sessions currently.
+- sftp_bytes_total - Total number of bytes transferred via sftp by direction
+  (read, write).
+- sftp_files_total - Total number of files by direction (sent, received).
+- sftp_stat_total - Total number of times `stat` was called on a path.
+- sftp_list_total - Total number of times `list` was called on a path.
 
 ## Design Decisions
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,6 @@
-## TODO
+# TODO
+
+## Authorization
 
 - Groups are probably what most users are going to want to use to configure all
   this. The closest to the OpenID spec would be via adding extra scopes that add
@@ -13,6 +15,31 @@
   handled in the provider backend and it is unclear how easy that'll be. It is
   possible in auth0, so I'll go down this route for now.
 
+  Note: it looks like Google might require addition verification to get the
+  `groups()` scope "externally".
+
+## TUI
+
 - Is there a way to do FPS on a per-session basis with prometheus? Naively the
   way to do it would be to have a per-session label value, but that would be
   crazy for cardinality.
+
+## SFTP
+
+- Document that the permissions here are different than for the dashboard. You
+  can get away with `get` and `exec` on ~everything as long as you use `scp`.
+  Anything `sftp` is going to do a `readdir` and require `list`.
+- The API for `russh_sftp` feels nicer than the one for dashboard currently -
+  hand off a channel entirely instead of dealing with `data()` to begin with.
+  Should `Dashboard` get reimplemented to take something like
+  `async Read + Write` instead? I think I didn't do it this way to being with
+  because of writes being consumed entirely.
+- Allow globs in file paths, eg `/*/nginx**/etc/passwd`.
+- Return an error that is nicer than "no files found" when a container doesn't
+  have cat/ls.
+
+## SSH Functionality
+
+- Allow `ssh` directly into a pod without starting the dashboard.
+- Enable `ssh -L` for forwarding requests _into_ a pod.
+- Enable `ssh -R` for forwarding a remote service _into_ a localhost.

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -7,6 +7,7 @@ use k8s_openapi::api::authorization::v1::{
     ResourceAttributes, SelfSubjectAccessReview, SelfSubjectAccessReviewSpec,
     SubjectAccessReviewStatus,
 };
+pub use key::Key;
 use kube::api::{Api, PostParams};
 
 use crate::ssh::{Authenticate, Controller};

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,10 +1,12 @@
 pub mod age;
 pub mod container;
+pub mod file;
 pub mod pod;
 pub mod store;
 
 use color_eyre::Section;
 use eyre::{eyre, Result};
+pub use file::File;
 use futures::StreamExt;
 use itertools::Itertools;
 use json_value_merge::Merge;

--- a/src/resources/container/file.rs
+++ b/src/resources/container/file.rs
@@ -1,0 +1,172 @@
+use std::path::Path;
+
+use eyre::{eyre, Result};
+use k8s_openapi::api::core::v1::Pod;
+use kube::Api;
+use russh_sftp::protocol;
+use umask::Mode;
+
+use super::Container;
+use crate::resources::{
+    pod::{PodExt, Proc},
+    File,
+};
+
+pub trait ContainerFiles {
+    async fn from_path(client: kube::Client, path: &File) -> Result<Container>;
+
+    async fn get_files(
+        &self,
+        client: kube::Client,
+        path: &Path,
+        contents: bool,
+    ) -> Result<Vec<protocol::File>>;
+
+    async fn read(&self, client: kube::Client, path: &Path) -> Result<Vec<u8>>;
+    async fn list(&self, client: kube::Client, path: &Path) -> Result<Vec<protocol::File>>;
+    async fn stat(&self, client: kube::Client, path: &Path) -> Result<protocol::FileAttributes>;
+}
+
+impl ContainerFiles for Container {
+    async fn from_path(client: kube::Client, path: &File<'_>) -> Result<Container> {
+        let File {
+            namespace: Some(ns),
+            pod: Some(pod),
+            container: Some(container),
+            ..
+        } = path
+        else {
+            return Err(eyre!("invalid path: {:?}", path));
+        };
+
+        let containers = Api::<Pod>::namespaced(client.clone(), ns)
+            .get(pod)
+            .await?
+            .containers(Some(container.to_string()));
+
+        containers
+            .first()
+            .ok_or(eyre!(
+                "container {container} not found in pod {pod} from namespace {ns}",
+            ))
+            .cloned()
+    }
+
+    async fn get_files(
+        &self,
+        client: kube::Client,
+        path: &Path,
+        contents: bool,
+    ) -> Result<Vec<protocol::File>> {
+        let full_path = path.to_string_lossy();
+
+        // It might be a better idea to use `stat` here instead of `ls`, there's a lot
+        // more control over the output. The downside is that it only stats a single
+        // thing. To get a directory, something like `*` ends up being required which'll
+        // need a shell (or find).
+        let mut cmd = vec!["ls", "-l", "--time-style=+%s"];
+
+        if !contents {
+            cmd.push("-d");
+        }
+
+        cmd.push(full_path.as_ref());
+
+        let (out, _) = Proc::new(self.clone()).exec(client.clone(), cmd).await?;
+
+        let files = std::str::from_utf8(&out)?;
+
+        if contents {
+            Ok(files
+                .lines()
+                .skip(1)
+                .map(|l| l.to_file(path))
+                .collect::<Vec<_>>())
+        } else {
+            Ok(files.lines().map(|l| l.to_file(path)).collect::<Vec<_>>())
+        }
+    }
+
+    #[tracing::instrument(skip(self, client))]
+    async fn read(&self, client: kube::Client, path: &Path) -> Result<Vec<u8>> {
+        let full_path = path.to_string_lossy();
+        let cmd = vec!["cat", full_path.as_ref()];
+
+        let (out, _) = Proc::new(self.clone()).exec(client.clone(), cmd).await?;
+
+        Ok(out)
+    }
+
+    #[tracing::instrument(skip(self, client))]
+    async fn list(&self, client: kube::Client, path: &Path) -> Result<Vec<protocol::File>> {
+        self.get_files(client, path, true).await
+    }
+
+    #[tracing::instrument(skip(self, client))]
+    async fn stat(&self, client: kube::Client, path: &Path) -> Result<protocol::FileAttributes> {
+        let files = self.get_files(client, path, false).await?;
+
+        files
+            .first()
+            .map_or(Err(eyre!("no files found")), |file| Ok(file.attrs.clone()))
+    }
+}
+
+trait ParseFile {
+    fn to_file(&self, path: &Path) -> protocol::File;
+}
+
+impl ParseFile for &str {
+    fn to_file(&self, path: &Path) -> protocol::File {
+        self.split_ascii_whitespace().enumerate().fold(
+            protocol::File {
+                filename: String::new(),
+                longname: String::new(),
+                attrs: protocol::FileAttributes::default(),
+            },
+            |mut file, (i, s)| {
+                match i {
+                    0 => {
+                        file.attrs.permissions =
+                            Some(Mode::parse(&s[1..s.len()]).expect("valid mode").into());
+
+                        let mode = match s.chars().next().unwrap_or_default() {
+                            'b' => protocol::FileMode::BLK,
+                            'c' => protocol::FileMode::CHR,
+                            'd' => protocol::FileMode::DIR,
+                            'l' => protocol::FileMode::LNK,
+                            's' => protocol::FileMode::SOCK,
+                            _ => protocol::FileMode::REG,
+                        };
+
+                        file.attrs.set_type(mode);
+                    }
+                    2 => file.attrs.user = Some(s.to_string()),
+                    3 => file.attrs.group = Some(s.to_string()),
+                    4 => file.attrs.size = Some(s.parse().unwrap()),
+                    5 => {
+                        file.attrs.mtime = Some(s.parse().unwrap());
+                    }
+                    // This is used for both `stat` and `list`. When used via `stat`, `ls` returns
+                    // an absolute path for the file (or directory). When used via `list`, `ls`
+                    // returns the relative path based on the directory that was listed.
+                    6 => {
+                        let out_path = Path::new(s);
+
+                        if out_path.is_absolute() {
+                            file.filename =
+                                out_path.file_name().unwrap().to_string_lossy().to_string();
+                            file.longname = out_path.to_string_lossy().to_string();
+                        } else {
+                            file.filename = s.to_string();
+                            file.longname = path.join(s).to_string_lossy().to_string();
+                        }
+                    }
+                    _ => {}
+                }
+
+                file
+            },
+        )
+    }
+}

--- a/src/resources/file.rs
+++ b/src/resources/file.rs
@@ -1,0 +1,240 @@
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
+
+use eyre::{eyre, Result};
+use k8s_openapi::api::core::v1::{Namespace, Pod};
+use kube::{api::ListParams, Api, ResourceExt};
+use russh_sftp::protocol::{self, FileAttributes, FileMode};
+
+use super::{
+    container::{Container, ContainerExt, ContainerFiles},
+    pod::PodExt,
+};
+
+trait FileExt {
+    fn to_file(&self) -> protocol::File;
+}
+
+impl FileExt for PathBuf {
+    fn to_file(&self) -> protocol::File {
+        protocol::File {
+            filename: self
+                .as_path()
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into(),
+            longname: self.to_string_lossy().into(),
+            attrs: FileAttributes {
+                permissions: Some(FileMode::DIR.bits()),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl FileExt for Namespace {
+    fn to_file(&self) -> protocol::File {
+        ["/", self.name_any().as_str()]
+            .iter()
+            .collect::<PathBuf>()
+            .to_file()
+    }
+}
+
+impl FileExt for Pod {
+    fn to_file(&self) -> protocol::File {
+        [
+            "/",
+            self.namespace().expect("pods have namespaces").as_str(),
+            self.name_any().as_str(),
+        ]
+        .iter()
+        .collect::<PathBuf>()
+        .to_file()
+    }
+}
+
+impl FileExt for Container {
+    fn to_file(&self) -> protocol::File {
+        [
+            "/",
+            self.namespace()
+                .expect("containers have namespaces")
+                .as_str(),
+            self.pod_name().as_str(),
+            self.name_any().as_str(),
+        ]
+        .iter()
+        .collect::<PathBuf>()
+        .to_file()
+    }
+}
+
+#[derive(Debug)]
+pub struct File<'a> {
+    pub namespace: Option<Cow<'a, str>>,
+    pub pod: Option<Cow<'a, str>>,
+    pub container: Option<Cow<'a, str>>,
+    pub path: Option<PathBuf>,
+}
+
+impl<'a> File<'a> {
+    pub fn new(path: &'a Path) -> Self {
+        let segments: Vec<Cow<str>> = path.iter().map(|s| s.to_string_lossy()).collect();
+
+        let namespace = segments.get(1).cloned();
+        let pod = segments.get(2).cloned();
+        let container = segments.get(3).cloned();
+        let path = segments
+            .iter()
+            .skip(4)
+            .fold(PathBuf::from("/"), |mut path, segment| {
+                path.push(segment.to_string());
+                path
+            });
+
+        Self {
+            namespace,
+            pod,
+            container,
+            path: if segments.len() > 4 { Some(path) } else { None },
+        }
+    }
+
+    pub async fn list(&self, client: kube::Client) -> Result<Vec<protocol::File>> {
+        match self {
+            File {
+                namespace: None, ..
+            } => Ok(Api::<Namespace>::all(client)
+                .list(&ListParams::default())
+                .await?
+                .iter()
+                .map(Namespace::to_file)
+                .collect()),
+            File {
+                namespace: Some(ns),
+                pod: None,
+                ..
+            } => Ok(Api::<Pod>::namespaced(client, ns)
+                .list(&ListParams::default())
+                .await?
+                .iter()
+                .map(Pod::to_file)
+                .collect()),
+            File {
+                namespace: Some(ns),
+                pod: Some(pod),
+                container: None,
+                ..
+            } => Ok(Api::<Pod>::namespaced(client, ns)
+                .get(pod)
+                .await?
+                .containers(None)
+                .iter()
+                .map(Container::to_file)
+                .collect()),
+            File {
+                namespace: Some(ns),
+                pod: Some(pod),
+                container: Some(container),
+                path,
+            } => {
+                let containers = Api::<Pod>::namespaced(client.clone(), ns)
+                    .get(pod)
+                    .await?
+                    .containers(Some(container.to_string()));
+
+                containers
+                    .first()
+                    .ok_or(eyre!(
+                        "container {container} not found in pod {pod} from namespace {ns}",
+                    ))?
+                    .list(
+                        client,
+                        path.as_ref().map_or(Path::new("/"), PathBuf::as_path),
+                    )
+                    .await
+            }
+        }
+    }
+
+    pub async fn stat(&self, client: kube::Client) -> Result<FileAttributes> {
+        match self {
+            File {
+                namespace: None, ..
+            } => Ok(FileAttributes::dir()),
+            File {
+                namespace: Some(ns),
+                pod: None,
+                ..
+            } => Ok(Api::<Namespace>::all(client)
+                .get(ns)
+                .await
+                .map(|_| FileAttributes::dir())?),
+            File {
+                namespace: Some(ns),
+                pod: Some(pod),
+                container: None,
+                ..
+            } => Ok(Api::<Pod>::namespaced(client, ns)
+                .get(pod)
+                .await
+                .map(|_| FileAttributes::dir())?),
+            File {
+                container: Some(_),
+                path: None,
+                ..
+            } => Ok(Container::from_path(client, self)
+                .await
+                .map(|_| FileAttributes::dir())?),
+            File {
+                path: Some(path), ..
+            } => {
+                Container::from_path(client.clone(), self)
+                    .await?
+                    .stat(client, path)
+                    .await
+            }
+        }
+    }
+
+    pub async fn read(&self, client: kube::Client) -> Result<Vec<u8>> {
+        match self {
+            File {
+                path: Some(path), ..
+            } => {
+                Container::from_path(client.clone(), self)
+                    .await?
+                    .read(client, path)
+                    .await
+            }
+            _ => Err(eyre!("invalid path: {:?}", self)),
+        }
+    }
+}
+
+impl std::fmt::Display for File<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "namespace: {:?} pod: {:?} container: {:?} path: {:?}",
+            self.namespace, self.pod, self.container, self.path
+        )
+    }
+}
+
+trait FileDir {
+    fn dir() -> FileAttributes;
+}
+
+impl FileDir for FileAttributes {
+    fn dir() -> FileAttributes {
+        FileAttributes {
+            permissions: Some(FileMode::DIR.bits()),
+            ..Default::default()
+        }
+    }
+}

--- a/src/resources/pod.rs
+++ b/src/resources/pod.rs
@@ -1,3 +1,5 @@
+pub mod proc;
+
 use std::{borrow::Borrow, cmp::Ordering, error::Error, fmt::Display, sync::Arc};
 
 use chrono::{TimeDelta, Utc};
@@ -9,6 +11,7 @@ use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1,
 };
 use kube::ResourceExt;
+pub use proc::Proc;
 use ratatui::{
     layout::Constraint,
     widgets::{Cell, Row},
@@ -221,7 +224,7 @@ impl PodExt for Pod {
             .map(|spec| {
                 spec.containers
                     .iter()
-                    .map(|c| Container::new(c.clone()))
+                    .map(|c| Container::new(self.clone(), c.clone()))
                     .collect()
             })
             .unwrap_or_default();

--- a/src/resources/pod/proc.rs
+++ b/src/resources/pod/proc.rs
@@ -1,0 +1,56 @@
+use eyre::{eyre, Result};
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, AttachParams};
+use tokio::io::AsyncReadExt;
+
+use super::{StatusError, StatusExt};
+use crate::resources::container::{Container, ContainerExt};
+
+pub struct Proc {
+    container: Container,
+}
+
+impl Proc {
+    pub fn new(container: Container) -> Self {
+        Self { container }
+    }
+
+    pub async fn exec(&self, client: kube::Client, cmd: Vec<&str>) -> Result<(Vec<u8>, Vec<u8>)> {
+        let mut proc = Api::<Pod>::namespaced(
+            client,
+            self.container
+                .namespace()
+                .expect("containers have namespaces")
+                .as_str(),
+        )
+        .exec(
+            self.container.pod_name().as_str(),
+            cmd,
+            &AttachParams {
+                container: Some(self.container.name_any()),
+                stdout: true,
+                stderr: true,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        let status = proc.take_status().ok_or(eyre!("status not available"))?;
+        let mut stdout = proc.stdout().ok_or(eyre!("stdout not available"))?;
+        let mut stderr = proc.stderr().ok_or(eyre!("stderr not available"))?;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+
+        stdout.read_to_end(&mut out).await?;
+        stderr.read_to_end(&mut err).await?;
+
+        if let Some(status) = status.await {
+            if !status.is_success() {
+                return Err(eyre!(StatusError::new(status)));
+            }
+        }
+
+        Ok((out, err))
+    }
+}

--- a/src/ssh/session/sftp.rs
+++ b/src/ssh/session/sftp.rs
@@ -1,0 +1,228 @@
+use std::path::Path;
+
+use eyre::Result;
+use lazy_static::lazy_static;
+use prometheus::{
+    opts, register_int_counter, register_int_counter_vec, register_int_gauge, IntCounter,
+    IntCounterVec, IntGauge,
+};
+use prometheus_static_metric::make_static_metric;
+use russh_sftp::{
+    protocol::{self, Attrs, Data, FileAttributes, Handle, Name, OpenFlags, Status, StatusCode},
+    server,
+};
+
+use crate::resources::File;
+
+make_static_metric! {
+    pub struct DirectionVec: IntCounter {
+        "direction" => {
+            sent,
+            received,
+        }
+    }
+}
+
+lazy_static! {
+    static ref SFTP_ACTIVE: IntGauge =
+        register_int_gauge!("sftp_active_sessions", "Number of active SFTP sessions").unwrap();
+    static ref SFTP_BYTES_VEC: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "sftp_bytes_total",
+            "Number of bytes that have been transferred via SFTP",
+        ),
+        &["direction"],
+    )
+    .unwrap();
+    static ref SFTP_BYTES: DirectionVec = DirectionVec::from(&SFTP_BYTES_VEC);
+    static ref SFTP_FILES_VEC: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "sftp_files_total",
+            "Number of files that have been transferred via SFTP",
+        ),
+        &["direction"],
+    )
+    .unwrap();
+    static ref SFTP_FILES: DirectionVec = DirectionVec::from(&SFTP_FILES_VEC);
+    static ref SFTP_STAT: IntCounter =
+        register_int_counter!("sftp_stat_total", "Total stat calls via SFTP").unwrap();
+    static ref SFTP_LIST: IntCounter =
+        register_int_counter!("sftp_list_total", "Total list calls via SFTP").unwrap();
+}
+
+enum State {
+    Unknown,
+    OpenFile,
+    FileComplete,
+    OpenDir,
+    DirComplete,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+pub struct Handler {
+    client: kube::Client,
+    state: State,
+}
+
+// TODO: would it be better to add a `Store<Pod>` to this?
+impl Handler {
+    pub fn new(client: kube::Client) -> Self {
+        SFTP_ACTIVE.inc();
+
+        Self {
+            client,
+            state: State::default(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl server::Handler for Handler {
+    type Error = StatusCode;
+
+    fn unimplemented(&self) -> Self::Error {
+        StatusCode::OpUnsupported
+    }
+
+    async fn open(
+        &mut self,
+        id: u32,
+        filename: String,
+        _: OpenFlags,
+        _: FileAttributes,
+    ) -> Result<Handle, Self::Error> {
+        self.state = State::OpenFile;
+
+        Ok(Handle {
+            id,
+            handle: filename,
+        })
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn read(
+        &mut self,
+        id: u32,
+        handle: String,
+        _offset: u64,
+        _len: u32,
+    ) -> Result<Data, Self::Error> {
+        if !matches!(self.state, State::OpenFile) {
+            return Err(StatusCode::Eof);
+        }
+
+        SFTP_FILES.sent.inc();
+
+        self.state = State::FileComplete;
+
+        tracing::info!("read file");
+
+        let result = File::new(Path::new(handle.as_str()))
+            .read(self.client.clone())
+            .await
+            .map(|data| Data { id, data })
+            .map_err(|_| StatusCode::NoSuchFile);
+
+        if let Ok(data) = &result {
+            SFTP_BYTES.sent.inc_by(data.data.len() as u64);
+        }
+
+        result
+    }
+
+    async fn close(&mut self, id: u32, _handle: String) -> Result<Status, Self::Error> {
+        Ok(Status {
+            id,
+            status_code: StatusCode::Ok,
+            error_message: "Ok".to_string(),
+            language_tag: "en-US".to_string(),
+        })
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn write(
+        &mut self,
+        _id: u32,
+        _handle: String,
+        _offset: u64,
+        _data: Vec<u8>,
+    ) -> Result<Status, Self::Error> {
+        tracing::info!("write");
+
+        Err(StatusCode::OpUnsupported)
+    }
+
+    async fn opendir(&mut self, id: u32, path: String) -> Result<Handle, Self::Error> {
+        self.state = State::OpenDir;
+
+        Ok(Handle { id, handle: path })
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn readdir(&mut self, id: u32, handle: String) -> Result<Name, Self::Error> {
+        SFTP_LIST.inc();
+        tracing::info!("readdir");
+
+        if !matches!(self.state, State::OpenDir) {
+            return Err(StatusCode::Eof);
+        }
+
+        self.state = State::DirComplete;
+
+        let path = Path::new(handle.as_str());
+
+        File::new(path)
+            .list(self.client.clone())
+            .await
+            .map(|files| Name { id, files })
+            .map_err(|e| {
+                tracing::error!("readdir: {:?}", e);
+                StatusCode::NoSuchFile
+            })
+    }
+
+    async fn realpath(&mut self, id: u32, _: String) -> Result<Name, Self::Error> {
+        Ok(Name {
+            id,
+            files: vec![protocol::File {
+                filename: String::new(),
+                longname: String::new(),
+                attrs: FileAttributes::default(),
+            }],
+        })
+    }
+
+    async fn stat(&mut self, id: u32, path: String) -> Result<Attrs, Self::Error> {
+        SFTP_STAT.inc();
+        tracing::info!("stat: {}", path);
+
+        File::new(Path::new(path.as_str()))
+            .stat(self.client.clone())
+            .await
+            .map(|attrs| Attrs { id, attrs })
+            .map_err(|e| {
+                tracing::error!("stat: {:?}", e);
+                StatusCode::NoSuchFile
+            })
+    }
+
+    async fn lstat(&mut self, id: u32, path: String) -> Result<Attrs, Self::Error> {
+        self.stat(id, path).await
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn fstat(&mut self, id: u32, path: String) -> Result<Attrs, Self::Error> {
+        self.stat(id, path).await
+    }
+}
+
+impl Drop for Handler {
+    fn drop(&mut self) {
+        SFTP_ACTIVE.dec();
+    }
+}

--- a/src/ssh/session/state.rs
+++ b/src/ssh/session/state.rs
@@ -1,0 +1,103 @@
+use std::str;
+
+use eyre::{eyre, Result};
+use replace_with::{replace_with_or_abort, replace_with_or_abort_and_return};
+use russh::{keys::key::PublicKey, server};
+
+use crate::{dashboard::Dashboard, identity::Identity, openid};
+
+#[derive(Debug, strum_macros::AsRefStr)]
+pub enum State {
+    // Used when all the fields of a variant have been removed and the next state is pending.
+    Unknown,
+    Unauthenticated,
+    KeyOffered(PublicKey),
+    CodeSent(openid::DeviceCode, Option<PublicKey>),
+    InvalidIdentity(Identity, Option<PublicKey>),
+    Authenticated(DebugClient, String),
+    ChannelOpen(russh::Channel<server::Msg>, DebugClient),
+    PtyStarted(Dashboard),
+    SftpStarted,
+}
+
+pub struct DebugClient(kube::Client);
+
+impl std::fmt::Debug for DebugClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "kube::Client")
+    }
+}
+
+impl AsRef<kube::Client> for DebugClient {
+    fn as_ref(&self) -> &kube::Client {
+        &self.0
+    }
+}
+
+impl State {
+    pub fn key_offered(&mut self, key: &PublicKey) {
+        *self = State::KeyOffered(key.clone());
+    }
+
+    pub fn code_sent(&mut self, code: &openid::DeviceCode) {
+        let key = match self {
+            State::KeyOffered(key) => Some(key.clone()),
+            State::InvalidIdentity(_, key) => key.clone(),
+            _ => None,
+        };
+
+        *self = State::CodeSent(code.clone(), key);
+    }
+
+    pub fn code_used(&mut self) {
+        let State::CodeSent(_, key) = self else {
+            *self = State::Unauthenticated;
+
+            return;
+        };
+
+        match key {
+            Some(key) => {
+                *self = State::KeyOffered(key.clone());
+            }
+            None => {
+                *self = State::Unauthenticated;
+            }
+        }
+    }
+
+    pub fn invalid_identity(&mut self, identity: Identity) {
+        let key = match self {
+            State::KeyOffered(key) => Some(key.clone()),
+            _ => None,
+        };
+
+        *self = State::InvalidIdentity(identity, key);
+    }
+
+    pub fn authenticated(&mut self, client: kube::Client, method: String) {
+        *self = State::Authenticated(DebugClient(client), method);
+    }
+
+    pub fn channel_opened(&mut self, channel: russh::Channel<server::Msg>) {
+        replace_with_or_abort(self, |self_| match self_ {
+            State::Authenticated(client, _) => State::ChannelOpen(channel, client),
+            _ => self_,
+        });
+    }
+
+    pub fn take_channel_open(&mut self) -> Result<(russh::Channel<server::Msg>, DebugClient)> {
+        replace_with_or_abort_and_return(self, |self_| match self_ {
+            State::ChannelOpen(channel, client) => (Ok((channel, client)), State::Unknown),
+            _ => (Err(eyre!("channel not open")), self_),
+        })
+    }
+
+    pub fn pty_started(&mut self, dashboard: Dashboard) {
+        *self = State::PtyStarted(dashboard);
+    }
+
+    pub fn sftp_started(&mut self) {
+        *self = State::SftpStarted;
+    }
+}

--- a/src/widget/pod/shell.rs
+++ b/src/widget/pod/shell.rs
@@ -116,7 +116,7 @@ impl Command {
 
     fn input(container: &Container) -> Text {
         Text::default()
-            .with_title(container.name_any())
+            .with_title(container.name_any().as_str())
             .with_content(COMMAND)
     }
 


### PR DESCRIPTION
This commit allows *read* access to the files in a container via the `sftp` protocol which is
implemented by `scp` among others.

Additionally:

- `ContainerExt.name_any` now matches the API that `ResourceExt` uses.
- `Proc` allows for trivial execution on pods and receiving stdout/stderr.
- `session::State` got moved into its own file.
- `session::State` can now pass `Channel` around.