### PR TITLE
feat(network): added local port forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-tui"
+version = "5.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "428c2992b874104caf39204b05bf89eab4ceefdd4fcb26caa6759906f547f8e8"
+dependencies = [
+ "nom",
+ "ratatui",
+ "simdutf8",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +1987,7 @@ dependencies = [
 name = "kuberift"
 version = "0.0.0-UNSTABLE"
 dependencies = [
+ "ansi-to-tui",
  "async-trait",
  "cata",
  "chrono",
@@ -3470,9 +3484,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -3489,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3511,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -3633,6 +3647,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple_asn1"
@@ -4024,9 +4044,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4037,6 +4057,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ keywords = ["cli", "kubernetes", "ssh", "tui", "terminal"]
 categories = ["command-line-interface"]
 
 [dependencies]
+ansi-to-tui = "=5.0.0-rc.1"
 async-trait = "0.1.81"
 cata = { version = "0.1.1" }
 chrono = { version = "0.4.38", features = ["serde"] }
@@ -61,15 +62,15 @@ russh = "0.45.0"
 russh-keys = "0.45.0"
 russh-sftp = "2.0.3"
 schemars = { version = "0.8.21", features = ["chrono"] }
-serde = { version = "1.0.208", features = ["derive"] }
-serde_json = "1.0.124"
+serde = { version = "1.0.209", features = ["derive"] }
+serde_json = "1.0.127"
 serde_path_to_error = "0.1.16"
 serde_yaml = "0.9.34"
 ssh-key = "0.6.6"
 strum_macros = "0.26.4"
 syntect = "5.2.0"
 syntect-tui = "3.0.3"
-tokio = { version = "1.39.3", features = ["full"] }
+tokio = { version = "1.40.0", features = ["full", "tracing"] }
 tokio-util = { version = "0.7.11", features = ["io-util"] }
 tracing = "0.1.40"
 tracing-error = { version = "0.2.0", features = ["traced-error"] }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,3 +41,22 @@ When you run `just dev-push`, an image at `kuberift:5432/kuberift:latest` will
 be available to run inside the cluster.
 
 [k3d]: https://k3d.io/v5.6.3/#releases
+
+## Forwarding
+
+If testing port forwarding and running the service locally (aka not on the
+cluster), you won't have access to any of the DNS or IP addresses that might be
+forwarded. To work around this, modify `/etc/hosts`:
+
+```txt
+127.0.0.1 localhost.default.svc
+```
+
+Then you'll be able to test forwarding to localhost via:
+
+```bash
+ssh -L 9090:svc/default/localhost:9091 me@localhost -p 2222
+```
+
+Testing `pods` and `nodes` requires running on the cluster as the response from
+`addr` for those is IP addresses.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ You can:
 
 - Get a shell in running pods - just like you would with SSH normally.
 - Access the logs for running and exited containers in a pod.
-- `scp` files from pods. sftp clients work as well.
+- Forward a local port remotely, allowing access to services and pods in the
+  cluster.
+  - `scp` files from pods. sftp clients work as well.
 
 ![demo](./assets/demo.gif)
 
@@ -22,10 +24,10 @@ You can:
    cluster.
 1. Grant your email address access to the cluster. Choose `cluster-admin` if
    you'd like something simple to check out how things work. For more details on
-   the minimum possible permissions, read the [Authorization](#authorization)
-   section. The email address is what you'll be using to authenticate against.
-   It can either be the one associated with a google or github account. Note,
-   the ID used for login and the providers available can all be configured.
+   the minimum possible permissions, read the [Authorization][auth] section. The
+   email address is what you'll be using to authenticate against. It can either
+   be the one associated with a google or github account. Note, the ID used for
+   login and the providers available can all be configured.
 
    ```bash
    kuberift users grant <cluster-role> <email-address>
@@ -72,8 +74,39 @@ To get to the dashboard, you can run:
 ssh anything@my-remote-host-or-ip -p 2222
 ```
 
-As you're authenticated either via OpenID or public key, the username is not
-used.
+The provided username is not used as your identity is authenticated via other
+mechanisms.
+
+### Port Forward
+
+You can forward requests from a local port into a resource on the remote
+cluster. The supported resources are `nodes`, `pods` and `services`. See the
+[authorization][auth] section for details on required RBAC.
+
+To forward port 9090 on your local system to 80 on the cluster, you can run:
+
+```bash
+ssh me@my-cluster -p 2222 -L 9090:service/default/remote-service:80
+```
+
+The first time 9090 is accessed, a connection will be made. Pay attention to the
+dashboard as any errors establishing this session will be reflected there.
+
+The connection string format is `<resource>/<namespace>/<name>`. As nodes are
+not namespaced, the format is `<resource>/<name>`.
+
+Unlike the API server proxy, this works for any TCP service and is not limited
+to HTTP/HTTPS. For example, you can ssh directly to a node in the cluster with:
+
+```bash
+ssh me@my-cluster -p 2222 -L 3333:no/my-node:22
+```
+
+With that running in one terminal, you can run this in another:
+
+```bash
+ssh my-node-username@localhost -p 3333
+```
 
 ### SFTP
 
@@ -92,221 +125,22 @@ scp -P 2222 me@localhost:/default/nginx/nginx/etc/hosts /tmp
 It can be a little easier to navigate all this with an sftp client as that'll
 render the file tree natively for you.
 
-## Deployment
-
-The `kuberift` server needs access to your cluster's API server and credentials
-to connect to it. There are a couple ways to do this:
-
-- On cluster - you can run it on cluster. Check out the [helm chart][helm-chart]
-  for an easy way to get started. By running it on cluster, you get access and
-  credentials automatically. The server then needs to be exposed so that you can
-  connect to it. This can be done by any TCP load balancer. If you're running in
-  the cloud, setting the server's service to `type: LoadBalancer` is the
-  easiest. Alternatives include using the [gateway api][gateway-api] or
-  configuring your ingress controller to route TCP.
-- Off cluster - if you're already using jump hosts to get into your cluster,
-  kuberift can run there. All you need to do is create a `kubeconfig` that uses
-  the correct service account. There are [some plugins][sa-plugin] to make this
-  easy. You'll still need a valid `ClusterRole` and `ClusterRoleBinding` setup.
-  Take a look at the sample [rbac][helm-rbac] to see what do to there.
-
-[gateway-api]: https://gateway-api.sigs.k8s.io
-[helm-chart]: #helm
-[sa-plugin]:
-  https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin
-[helm-rbac]: helm/templates/rbac.yaml
-
-### Helm
-
-There is a provided `getting-started.yaml` set of values. To install this on
-your cluster, you can run:
-
-```bash
-helm install kuberift oci://ghcr.io/grampelberg/helm/kuberift \
-  -n kuberift --create-namespace \
-  --version $(curl -L https://api.github.com/repos/grampelberg/kuberift/tags | jq -r '.[0].name' | cut -c2-) \
-  -f https://raw.githubusercontent.com/grampelberg/kuberift/main/helm/getting-started.yaml
-```
-
-Note: this exposes the kuberift service externally by default. To get that IP
-address, you can run:
-
-```bash
-kubectl -n kuberift get service server --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
-```
-
-For more detailed instructions, take a look at the [README][helm-readme].
-
-[helm-readme]: helm/README.md
-
-### Bring Your Own Provider
-
-By default, kuberift provides Github and Google authentication via.
-[auth0][auth0]. To get your own setup using auth0, check out their
-[instructions][auth0-setup].
-
-You can, alternatively, use your own provider. It must support the [device
-code][device-code] flow and have a URL that has the openid configuration. Take a
-look at the configuration for `kuberift serve` for the required values.
-
-[auth0]: https://auth0.com
-[auth0-setup]:
-  https://auth0.com/docs/get-started/authentication-and-authorization-flow/device-authorization-flow/call-your-api-using-the-device-authorization-flow#prerequisites
-[device-code]: https://www.oauth.com/oauth2-servers/device-flow/
-
-## Server RBAC
-
-The kuberift server needs to be able to:
-
-- Impersonate users and groups.
-- Manage `keys`.
-- Optionally update the CRDs.
-
-To do the minimum of this, you can use the following `ClusterRole` + `Role`. For
-a more in-depth example, take a look at the
-[helm config](helm/templates/rbac.yaml).
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-name: impersonator
-rules:
-  - apiGroups:
-      - ''
-    resources:
-      - users
-      - groups
-    verbs:
-      - 'impersonate'
-    # Restrict the groups/users that can be impersonated through kuberift.
-    # resourceNames:
-    #   - foo@bar.com
-    #   - my_group
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-name: kuberift
-rules:
-  - apiGroups:
-      - 'key.kuberift.com'
-    resources:
-      - keys
-    verbs:
-      - '*'
----
-```
-
-## Identity (Authentication)
-
-Access is managed via k8s' RBAC system. This is managed with `User` and `Group`
-subjects in role bindings. Kuberift impersonates a user with optional groups.
-Authorization is then managed by k8s itself.
-
-There are two ways for an incoming SSH session to get a user identity:
-
-- OpenID - If the user does not have an authorized public key, the SSH session
-  prompts with an open id flow. When that flow is successful, the returned token
-  is mapped to a k8s identity. By default, this is the `email` claim in the
-  identity token. If you would like to map different claims and/or add groups,
-  take a look at the server configuration.
-- Public Key - By default, once a user has been authenticated with open id, they
-  will have a public key. This will contain the user and group information
-  extracted from the identity token. If you would like to skip OpenID entirely,
-  you can create `Key` resources, the `kuberift users key` can be used to do
-  this as an alternative to `kubectl`.
-
-To validate that a user has access, you can use the `kuberift users check`
-command. This is a great way to debug why users are not being allowed to
-connect.
-
-```bash
-kuberift users check foo@bar.com
-```
-
-## Authorization
-
-To be authorized, either the name or groups for a user need to have role
-bindings added to the cluster. The `kuberift users grant` command is one way to
-go about this, but it is purposely naive. To do something more flexible, you can
-check out `kubectl`:
-
-```bash
-kubectl create clusterrolebinding foo-bar-com --clusterrole=<my-role> --user=foo@bar.com
-```
-
-Note that you can use `RoleBinding` instead, but that comes with caveats. See
-the design decisions section for an explanation of what's happening there.
-
-### Minimum Permissions
-
-- List pods at the cluster level.
-
-## Metrics
-
-- bytes_received_total - Total number of bytes received. This should be keyboard
-  input.
-- channel_bytes_sent_total - Total number of bytes sent via a channel by IO type
-  (blocking, non-blocking). This is what the UI and raw modes use to send data
-  to the client. It will be different that the amount of bytes `russh` itself.
-- ssh_clients_total - Number of incoming connections.
-- ssh_session_errors_total - Number of non-IO related unhandled errors at the
-  session level.
-- session_total - Number of sessions created.
-- active_sessions - Number of currently active sessions.
-- session_duration_minutes - Duration of a session in minutes.
-- unexpected_state_total - Number of times an unexpected state was encountered.
-  This should only be incremented if there's a bug.
-- auth_attempts_total - Number of authentication attempts by method (publickey,
-  interactive). This can seem inflated because `publickey` will always be
-  attempted first and `interactive` will happen at least twice for every
-  success.
-- auth_results_total - Number of auth responses returned by method and result
-  (accept, partial, reject). Note that this can seem inflated because
-  `publickey` is always attempted first and provides a rejection before moving
-  onto other methods.
-- auth_succeeded_total - Number of fully authn and authz'd users. After this,
-  users can request a PTY.
-- code_generated_total - Number of codes generated for users. This is the first
-  half of the `interactive` mode.
-- code_checked_total - Number of codes that have been checked by result (valid,
-  invalid). This is the second half of the `interactive` mode and it is possible
-  that users retry after getting `invalid` because of something on the openid
-  provider side.
-- window_resize_total - Number of times the window has been asked to resize.
-- container_exec_duration_minutes - Number of minutes a raw terminal was running
-  exec'd into a pod.
-- table_filter_total - Number of times a table was filtered.
-- widget_views_total - Number of times a widget was created by resource
-  (container, pod) and type (cmd, log, yaml, ...).
-- requests_total - Number of requests that have come in by type (pty, sftp).
-- sftp_active_sessions - Total number of active sessions currently.
-- sftp_bytes_total - Total number of bytes transferred via sftp by direction
-  (read, write).
-- sftp_files_total - Total number of files by direction (sent, received).
-- sftp_stat_total - Total number of times `stat` was called on a path.
-- sftp_list_total - Total number of times `list` was called on a path.
-
-## Design Decisions
-
-- Instead of having a separate `User` CRD to track the user, we rely on k8s'
-  users/groups which are subjects on (Cluster)RoleBindings. Identity is
-  extracted from the openid tokens via claims (email by default) and that is
-  used to map to k8s concepts. The `Key` resource maps the values from a
-  previous token to the SSH key used during the original authentication attempt.
-  This key expires when the token itself would have and can be created manually
-  with any desired expiration.
-
-- The minimum viable access is `list` for `pods` across all namespaces.
-  Understanding what subset of a cluster users can see is a PITA. This is
-  because k8s cannot filter `list` requests to a subset. When combined with the
-  fact that `SelfSubjectRulesReview` only works on a per-namespace basis, it
-  becomes extremely expensive to understand what an individual user can see
-  across the entire cluster. This will be updated in the future but requires
-  namespaces to be available via UI elements.
-
 ## Releases
 
 - See releases for the latest tagged release.
 - The `unstable` tag is updated on every merge to main.
+
+## Documentation
+
+- [Architecture](docs/architecture.md)
+- [Auth][auth] - Deep dive on what's happening around auth and what the minimum
+  permissions are for each piece of functionality.
+- [Deployment](docs/deployment.md) - Figure out how to get running on your own
+  cluster.
+- [Development](DEVELOPMENT.md) - Some tips and tricks for doing development on
+  kuberift itself.
+- [Metrics](docs/metrics.md) - List of the possible metrics exported via.
+  prometheus.
+- [TODO](TODO.md) - A selection of outstanding functionality.
+
+[auth]: docs/auth.md

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,11 @@
   way to do it would be to have a per-session label value, but that would be
   crazy for cardinality.
 
+- There's a bug somewhere in `log_stream`. My k3d cluster restarted and while I
+  could get all the logs, the stream wouldn't keep running - it'd terminate
+  immediately. `stern` seemed to be working fine. Recreating the cluster caused
+  everything to work again.
+
 ## SFTP
 
 - Document that the permissions here are different than for the dashboard. You
@@ -43,3 +48,7 @@
 - Allow `ssh` directly into a pod without starting the dashboard.
 - Enable `ssh -L` for forwarding requests _into_ a pod.
 - Enable `ssh -R` for forwarding a remote service _into_ a localhost.
+
+## TCP/IP Forwarding
+
+- Implement `-R` for proxying from the cluster to localhost.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,19 @@
+# Architecture
+
+## Design Decisions
+
+- Instead of having a separate `User` CRD to track the user, we rely on k8s'
+  users/groups which are subjects on (Cluster)RoleBindings. Identity is
+  extracted from the openid tokens via claims (email by default) and that is
+  used to map to k8s concepts. The `Key` resource maps the values from a
+  previous token to the SSH key used during the original authentication attempt.
+  This key expires when the token itself would have and can be created manually
+  with any desired expiration.
+
+- The minimum viable access is `list` for `pods` across all namespaces.
+  Understanding what subset of a cluster users can see is a PITA. This is
+  because k8s cannot filter `list` requests to a subset. When combined with the
+  fact that `SelfSubjectRulesReview` only works on a per-namespace basis, it
+  becomes extremely expensive to understand what an individual user can see
+  across the entire cluster. This will be updated in the future but requires
+  namespaces to be available via UI elements.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,149 @@
+# Authentication and Authorization
+
+Kuberift utilizes external systems for both authn and authz. To fetch your
+identity, a combo of OpenID and the `keys` resource in your cluster are used.
+These map from something external to a `User` and `Group` inside of k8s.
+
+Once an identity has been established, k8s' RBAC system is used to verify what a
+user can do on the cluster. This is implemented by keeping kuberift's
+permissions to a minimum and impersonating the verified identities.
+
+## Identity (Authentication)
+
+There are two ways for an incoming SSH session to get a user identity:
+
+- OpenID - If the user does not have an authorized public key, the SSH session
+  prompts with an open id flow. When that flow is successful, the returned token
+  is mapped to a k8s identity. By default, this is the `email` claim in the
+  identity token. If you would like to map different claims and/or add groups,
+  take a look at the server configuration.
+- Public Key - By default, once a user has been authenticated with openid, they
+  will have a public key. This will contain the user and group information
+  extracted from the identity token. If you would like to skip OpenID entirely,
+  you can create `Key` resources, the `kuberift users key` can be used to do
+  this as an alternative to `kubectl`.
+
+To validate that a user has access, you can use the `kuberift users check`
+command. This is a great way to debug why users are not being allowed to
+connect.
+
+```bash
+kuberift users check foo@bar.com
+```
+
+## Authorization
+
+To be authorized, either the name or groups for a user need to have role
+bindings added to the cluster. The `kuberift users grant` command is one way to
+go about this, but it is purposely naive. To do something more flexible, you can
+check out `kubectl`:
+
+```bash
+kubectl create clusterrolebinding foo-bar-com --clusterrole=<my-role> --user=foo@bar.com
+```
+
+Note that you can use a `RoleBinding` instead, but only for specific
+functionality.
+
+### SSH RBAC
+
+The minimum permissions are:
+
+```yaml
+resources: ['pods']
+verbs: ['list', 'watch']
+```
+
+To see logs:
+
+```yaml
+resources: ['"pods/log']
+verbs: ['get']
+```
+
+To get a shell:
+
+```yaml
+resources: ['pods/exec']
+verbs: ['create']
+```
+
+Note: without the full permissions it is possible that the dashboard has some
+issues rendering.
+
+### Port Forwarding RBAC
+
+For each supported resource type (nodes, services, pods), you need:
+
+- `create` for `resource/proxy`
+- `get` for `resource`
+
+Notes:
+
+- `resourceNames` works for these but it is a little unwieldy for names that are
+  auto-generated such as `node` and `pod`.
+- For namespaced resources (`services`, `pods`), this can be a `RoleBinding`.
+
+Here's an example role for `pods`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: my-role
+rules:
+  - apiGroups: ['']
+    resources:
+      - pods/proxy
+    verbs:
+      - create
+    # resourceNames:
+    #   - my-statefulset-0
+  - apiGroups: ['']
+    resources:
+      - pods
+    verbs:
+      - get
+```
+
+### SFTP(SCP) RBAC
+
+To support `scp`, the minimum permissions are:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: my-role
+rules:
+  - apiGroups: ['']
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups: ['']
+    resources:
+      - pods
+    verbs:
+      - get
+```
+
+This will allow fetching files directly in addition to listing files that are
+pod specific (eg `/<namespace>/<pod>/<container>`).
+
+To list files at the cluster level, you'll need to add:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: my-role
+rules:
+  - apiGroups: ['']
+    resources:
+      - pods
+      - namespaces
+    verbs:
+      - get
+      - list
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,105 @@
+# Deployment
+
+The `kuberift` server needs access to your cluster's API server and credentials
+to connect to it. There are a couple ways to do this:
+
+- On cluster - you can run it on cluster. Check out the [helm chart][helm-chart]
+  for an easy way to get started. By running it on cluster, you get access and
+  credentials automatically. The server then needs to be exposed so that you can
+  connect to it. This can be done by any TCP load balancer. If you're running in
+  the cloud, setting the server's service to `type: LoadBalancer` is the
+  easiest. Alternatives include using the [gateway api][gateway-api] or
+  configuring your ingress controller to route TCP.
+- Off cluster - if you're already using jump hosts to get into your cluster,
+  kuberift can run there. All you need to do is create a `kubeconfig` that uses
+  the correct service account. There are [some plugins][sa-plugin] to make this
+  easy. You'll still need a valid `ClusterRole` and `ClusterRoleBinding` setup.
+  Take a look at the sample [rbac][helm-rbac] to see what do to there.
+
+[gateway-api]: https://gateway-api.sigs.k8s.io
+[helm-chart]: #helm
+[sa-plugin]:
+  https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin
+[helm-rbac]: helm/templates/rbac.yaml
+
+## Helm
+
+There is a provided `getting-started.yaml` set of values. To install this on
+your cluster, you can run:
+
+```bash
+helm install kuberift oci://ghcr.io/grampelberg/helm/kuberift \
+  -n kuberift --create-namespace \
+  --version $(curl -L https://api.github.com/repos/grampelberg/kuberift/tags | jq -r '.[0].name' | cut -c2-) \
+  -f https://raw.githubusercontent.com/grampelberg/kuberift/main/helm/getting-started.yaml
+```
+
+Note: this exposes the kuberift service externally by default. To get that IP
+address, you can run:
+
+```bash
+kubectl -n kuberift get service server --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+For more detailed instructions, take a look at the [README][helm-readme].
+
+[helm-readme]: helm/README.md
+
+## Bring Your Own Provider
+
+By default, kuberift provides Github and Google authentication via.
+[auth0][auth0]. To get your own setup using auth0, check out their
+[instructions][auth0-setup].
+
+You can, alternatively, use your own provider. It must support the [device
+code][device-code] flow and have a URL that has the openid configuration. Take a
+look at the configuration for `kuberift serve` for the required values.
+
+[auth0]: https://auth0.com
+[auth0-setup]:
+  https://auth0.com/docs/get-started/authentication-and-authorization-flow/device-authorization-flow/call-your-api-using-the-device-authorization-flow#prerequisites
+[device-code]: https://www.oauth.com/oauth2-servers/device-flow/
+
+## Server RBAC
+
+The kuberift server needs to be able to:
+
+- Impersonate users and groups.
+- Manage `keys`.
+- Optionally update the CRDs.
+
+To do the minimum of this, you can use the following `ClusterRole` + `Role`. For
+a more in-depth example, take a look at the
+[helm config](helm/templates/rbac.yaml).
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+name: impersonator
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - users
+      - groups
+    verbs:
+      - 'impersonate'
+    # Restrict the groups/users that can be impersonated through kuberift.
+    # resourceNames:
+    #   - foo@bar.com
+    #   - my_group
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+name: kuberift
+rules:
+  - apiGroups:
+      - 'key.kuberift.com'
+    resources:
+      - keys
+    verbs:
+      - '*'
+---
+```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,52 @@
+# Metrics
+
+- bytes_received_total - Total number of bytes received. This should be keyboard
+  input.
+- channel_bytes_sent_total - Total number of bytes sent via a channel by IO type
+  (blocking, non-blocking). This is what the UI and raw modes use to send data
+  to the client. It will be different that the amount of bytes `russh` itself.
+- ssh_clients_total - Number of incoming connections.
+- ssh_session_errors_total - Number of non-IO related unhandled errors at the
+  session level.
+- session_total - Number of sessions created.
+- active_sessions - Number of currently active sessions.
+- session_duration_minutes - Duration of a session in minutes.
+- unexpected_state_total - Number of times an unexpected state was encountered.
+  This should only be incremented if there's a bug.
+- auth_attempts_total - Number of authentication attempts by method (publickey,
+  interactive). This can seem inflated because `publickey` will always be
+  attempted first and `interactive` will happen at least twice for every
+  success.
+- auth_results_total - Number of auth responses returned by method and result
+  (accept, partial, reject). Note that this can seem inflated because
+  `publickey` is always attempted first and provides a rejection before moving
+  onto other methods.
+- auth_succeeded_total - Number of fully authn and authz'd users. After this,
+  users can request a PTY.
+- code_generated_total - Number of codes generated for users. This is the first
+  half of the `interactive` mode.
+- code_checked_total - Number of codes that have been checked by result (valid,
+  invalid). This is the second half of the `interactive` mode and it is possible
+  that users retry after getting `invalid` because of something on the openid
+  provider side.
+- container_exec_duration_minutes - Number of minutes a raw terminal was running
+  exec'd into a pod.
+- table_filter_total - Number of times a table was filtered.
+- widget_views_total - Number of times a widget was created by resource
+  (container, pod) and type (cmd, log, yaml, ...).
+- requests_total - Number of requests that have come in by type (pty, sftp,
+  window_resize).
+- sftp_active_sessions - Total number of active sessions currently.
+- sftp_bytes_total - Total number of bytes transferred via sftp by direction
+  (read, write).
+- sftp_files_total - Total number of files by direction (sent, received).
+- sftp_stat_total - Total number of times `stat` was called on a path.
+- sftp_list_total - Total number of times `list` was called on a path.
+- channels_total - Total number of channel actions by method (open_session,
+  direct_tcpip, ...).
+- stream_duration_seconds - Number of seconds a stream was alive by resource and
+  direction.
+- stream_bytes_total - Number of bytes transfered by resource, direction and
+  destination.
+- stream_total - Total number of streams by resource and direction.
+- stream_active - Currently active numberof streams by resource and direction.

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -25,6 +25,7 @@ rules:
       - kuberift.com
     resources:
       - keys
+      - keys/status
     verbs: ['*']
   - apiGroups:
       - apiextensions.k8s.io

--- a/helm/templates/server.yaml
+++ b/helm/templates/server.yaml
@@ -30,7 +30,7 @@ kind: Secret
 metadata:
   name: kuberift-server
   labels:
-    {{- include "labels" (dict "name" "kuberift-server" "component" "server" "global" $) | nindent 4 }}
+    {{- include "labels" (dict "name" "kuberift" "component" "server" "global" $) | nindent 4 }}
 data:
   {{- $old_sec := lookup "v1" "Secret" $.Release.Namespace "kuberift-server" }}
 
@@ -47,7 +47,7 @@ metadata:
 spec:
   {{- if .loadbalancer }}
   type: LoadBalancer
-  {{- else -}}
+  {{- else }}
   type: ClusterIP
   {{- end }}
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -19,6 +19,7 @@ pub enum Event {
     Input(Input),
     Resize(WindowSize),
     Goto(Vec<String>),
+    Error(String),
     Shutdown,
     Render,
     Finished(Result<()>),

--- a/src/io.rs
+++ b/src/io.rs
@@ -51,11 +51,11 @@ impl Channel {
 
 #[async_trait::async_trait]
 impl Writer for Channel {
-    fn blocking_writer(&self) -> impl Write {
+    fn blocking(&self) -> impl Write {
         SshWriter::new(self.id, self.handle.clone())
     }
 
-    fn async_writer(&self) -> impl AsyncWrite + Send + Unpin + 'static {
+    fn non_blocking(&self) -> impl AsyncWrite + Send + Unpin + 'static {
         SshWriter::new(self.id, self.handle.clone())
     }
 
@@ -170,8 +170,8 @@ impl AsyncWrite for SshWriter {
 
 #[async_trait::async_trait]
 pub trait Writer: Send + Sync + 'static {
-    fn async_writer(&self) -> impl AsyncWrite + Send + Unpin + 'static;
-    fn blocking_writer(&self) -> impl Write + Send;
+    fn blocking(&self) -> impl Write + Send;
+    fn non_blocking(&self) -> impl AsyncWrite + Send + Unpin + 'static;
 
     async fn shutdown(&self, _msg: String) -> Result<()> {
         Ok(())

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -3,6 +3,7 @@ pub mod container;
 pub mod file;
 pub mod pod;
 pub mod store;
+pub mod stream;
 
 use color_eyre::Section;
 use eyre::{eyre, Result};

--- a/src/resources/stream.rs
+++ b/src/resources/stream.rs
@@ -1,0 +1,374 @@
+use std::{pin::Pin, time::Duration};
+
+use chrono::Utc;
+use eyre::{eyre, Result};
+use futures::{future::join_all, Future};
+use k8s_openapi::api::{
+    authorization::v1::{ResourceAttributes, SelfSubjectAccessReview, SelfSubjectAccessReviewSpec},
+    core::v1::{Node, Pod, Service},
+};
+use kube::{api::PostParams, core::ErrorResponse, Api, Resource};
+use lazy_static::lazy_static;
+use prometheus::{
+    histogram_opts, opts, register_histogram_vec, register_int_counter_vec, register_int_gauge_vec,
+    HistogramVec, IntCounterVec, IntGaugeVec,
+};
+use prometheus_static_metric::make_static_metric;
+use russh::server::{self};
+use tokio::net::TcpStream;
+
+make_static_metric! {
+    pub struct ResourceVec: IntCounter {
+        "resource" => {
+            pod,
+            service,
+            node,
+        },
+        "direction" => {
+            ingress,
+            egress,
+        }
+    }
+    pub struct ResourceGaugeVec: IntGauge {
+        "resource" => {
+            pod,
+            service,
+            node,
+        },
+        "direction" => {
+            ingress,
+            egress,
+        }
+    }
+}
+
+lazy_static! {
+    static ref STREAM_DURATION: HistogramVec = register_histogram_vec!(
+        histogram_opts!(
+            "stream_duration_seconds",
+            "Stream duration",
+            vec!(0.1, 0.2, 0.3, 0.5, 0.8, 1.3, 2.1),
+        ),
+        &["resource", "direction"]
+    )
+    .unwrap();
+    static ref STREAM_BYTES: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "stream_bytes_total",
+            "Total number of bytes streamed by resource and direction"
+        ),
+        &["resource", "direction", "destination"]
+    )
+    .unwrap();
+    static ref STREAM_TOTAL_VEC: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "stream_total",
+            "Total number of streams by resource and direction"
+        ),
+        &["resource", "direction"]
+    )
+    .unwrap();
+    static ref STREAM_TOTAL: ResourceVec = ResourceVec::from(&STREAM_TOTAL_VEC);
+    static ref STREAM_ACTIVE_VEC: IntGaugeVec = register_int_gauge_vec!(
+        opts!(
+            "stream_active",
+            "Number of active streams by resource and direction"
+        ),
+        &["resource", "direction"]
+    )
+    .unwrap();
+    static ref STREAM_ACTIVE: ResourceGaugeVec = ResourceGaugeVec::from(&STREAM_ACTIVE_VEC);
+}
+
+static CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+
+struct Host {
+    client: kube::Client,
+    resource: String,
+    segments: Vec<String>,
+}
+
+impl Host {
+    fn new(client: kube::Client, host: &str) -> Result<Self> {
+        let segments: Vec<String> = host
+            .split('/')
+            .map(std::string::ToString::to_string)
+            .collect();
+
+        Ok(Self {
+            client,
+            resource: match segments
+                .first()
+                .map(std::string::String::as_str)
+                .ok_or_else(|| eyre!("resource not provided"))?
+            {
+                "pods" | "pod" | "po" => "pods".to_string(),
+                "services" | "service" | "svc" => "services".to_string(),
+                "nodes" | "node" | "no" => "nodes".to_string(),
+                _ => return Err(eyre!("resource not supported")),
+            },
+            segments,
+        })
+    }
+
+    fn resource(&self) -> &str {
+        self.resource.as_str()
+    }
+
+    async fn addr(&self) -> Result<String> {
+        match self.resource() {
+            "pods" => Pod::get_host(self.client.clone(), &self.segments[1..]).await,
+            "services" => Service::get_host(self.client.clone(), &self.segments[1..]).await,
+            "nodes" => Node::get_host(self.client.clone(), &self.segments[1..]).await,
+            x => Err(eyre!("resource {x} not supported")),
+        }
+    }
+}
+
+async fn access(client: kube::Client, attrs: ResourceAttributes) -> Result<bool> {
+    let access = Api::<SelfSubjectAccessReview>::all(client)
+        .create(
+            &PostParams::default(),
+            &SelfSubjectAccessReview {
+                spec: SelfSubjectAccessReviewSpec {
+                    resource_attributes: Some(attrs),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    Ok(access.status.map_or(false, |status| status.allowed))
+}
+
+pub async fn direct(
+    mut channel: russh::Channel<server::Msg>,
+    client: kube::Client,
+    host: String,
+    port: u16,
+) -> Result<()> {
+    let start = Utc::now();
+
+    let lookup = Host::new(client.clone(), host.as_str())?;
+    STREAM_TOTAL_VEC
+        .with_label_values(&[lookup.resource(), "ingress"])
+        .inc();
+    tracing::debug!(
+        resource = lookup.resource(),
+        direction = "ingress",
+        activity = "forward::tcpip",
+        "connection",
+    );
+
+    let addr = lookup.addr().await?;
+
+    let mut stream =
+        tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect((addr.as_str(), port)))
+            .await
+            .map_err(|_| {
+                eyre!(
+                    "connect to {addr}:{port} timed out after {}s",
+                    CONNECT_TIMEOUT.as_secs_f32()
+                )
+            })?
+            .map_err(|e| eyre!(e).wrap_err(format!("connect to {addr}:{port} failed")))?;
+
+    tracing::debug!("connected to {}:{}", host, port);
+
+    STREAM_ACTIVE_VEC
+        .with_label_values(&[lookup.resource(), "ingress"])
+        .inc();
+
+    let (mut dest_read, mut dest_write) = stream.split();
+    let mut src_write = channel.make_writer();
+    let mut src_read = channel.make_reader();
+
+    let mut bytes = join_all::<Vec<Pin<Box<dyn Future<Output = _> + Send>>>>(vec![
+        Box::pin(tokio::io::copy(&mut src_read, &mut dest_write)),
+        Box::pin(tokio::io::copy(&mut dest_read, &mut src_write)),
+    ])
+    .await;
+
+    STREAM_ACTIVE_VEC
+        .with_label_values(&[lookup.resource(), "ingress"])
+        .dec();
+    STREAM_DURATION
+        .with_label_values(&[lookup.resource(), "ingress"])
+        .observe(
+            (Utc::now() - start)
+                .to_std()
+                .expect("duration in range")
+                .as_secs_f64(),
+        );
+
+    let outgoing = bytes.pop().expect("outgoing bytes")?;
+    let incoming = bytes.pop().expect("incoming bytes")?;
+
+    STREAM_BYTES
+        .with_label_values(&[lookup.resource(), "ingress", "incoming"])
+        .inc_by(incoming);
+    STREAM_BYTES
+        .with_label_values(&[lookup.resource(), "ingress", "outgoing"])
+        .inc_by(outgoing);
+
+    tracing::debug!("connection lost for {}:{}", host, port);
+
+    Ok(())
+}
+
+trait Proxy {
+    async fn get_host(client: kube::Client, segments: &[String]) -> Result<String>;
+}
+
+impl Proxy for Pod {
+    async fn get_host(client: kube::Client, segments: &[String]) -> Result<String> {
+        let typ = Self::plural(&());
+        let format = format!("format is {typ}/<namespace>/<name>");
+
+        let Some(namespace) = segments.first() else {
+            return Err(eyre!(format).wrap_err("namespace not provided"));
+        };
+
+        let Some(name) = segments.get(1) else {
+            return Err(eyre!(format).wrap_err("name not provided"));
+        };
+
+        let path = segments.join("/");
+
+        if !access(
+            client.clone(),
+            ResourceAttributes {
+                resource: Some(format!("{typ}/proxy")),
+                verb: Some("create".to_string()),
+                namespace: Some((*namespace).to_string()),
+                name: Some((*name).to_string()),
+                ..Default::default()
+            },
+        )
+        .await?
+        {
+            return Err(eyre!("grant `create` for `{typ}/proxy`")
+                .wrap_err(format!("proxy for {path} is forbidden.")));
+        }
+
+        match Api::<Pod>::namespaced(client, namespace)
+            .get_opt(name)
+            .await
+        {
+            Ok(Some(pod)) => pod
+                .status
+                .ok_or(eyre!("{path} not running"))?
+                .pod_ip
+                .ok_or(eyre!("{path} ip not available")),
+            Ok(None) => Err(eyre!("{path} not found")),
+            Err(kube::Error::Api(ErrorResponse { code: 403, .. })) => {
+                Err(eyre!("grant `get` for `{typ}` to proxy")
+                    .wrap_err(format!("get forbidden for {path}")))
+            }
+            Err(kube::Error::Api(e)) => {
+                Err(eyre!(e.message).wrap_err(format!("failed getting {typ}")))
+            }
+            Err(e) => Err(eyre!(e).wrap_err(format!("failed getting {typ}"))),
+        }
+    }
+}
+
+impl Proxy for Service {
+    async fn get_host(client: kube::Client, segments: &[String]) -> Result<String> {
+        let typ = Self::plural(&());
+        let format = format!("format is {typ}/<namespace>/<name>");
+
+        let Some(namespace) = segments.first() else {
+            return Err(eyre!(format).wrap_err("namespace not provided"));
+        };
+
+        let Some(name) = segments.get(1) else {
+            return Err(eyre!(format).wrap_err("name not provided"));
+        };
+
+        let path = segments.join("/");
+
+        if !access(
+            client.clone(),
+            ResourceAttributes {
+                resource: Some(format!("{typ}/proxy")),
+                verb: Some("create".to_string()),
+                namespace: Some((*namespace).to_string()),
+                name: Some((*name).to_string()),
+                ..Default::default()
+            },
+        )
+        .await?
+        {
+            return Err(eyre!("grant `create` for `{typ}/proxy`")
+                .wrap_err(format!("proxy for {path} is forbidden.")));
+        }
+
+        match Api::<Service>::namespaced(client, namespace)
+            .get_opt(name)
+            .await
+        {
+            Ok(Some(_)) => Ok([name, namespace, "svc"].join(".")),
+            Ok(None) => Err(eyre!("{path} not found")),
+            Err(kube::Error::Api(ErrorResponse { code: 403, .. })) => {
+                Err(eyre!("grant `get` for `{typ}` to proxy")
+                    .wrap_err(format!("get forbidden for {path}")))
+            }
+            Err(kube::Error::Api(e)) => {
+                Err(eyre!(e.message).wrap_err(format!("failed getting {typ}")))
+            }
+            Err(e) => Err(eyre!(e).wrap_err(format!("failed getting {typ}"))),
+        }
+    }
+}
+
+impl Proxy for Node {
+    async fn get_host(client: kube::Client, segments: &[String]) -> Result<String> {
+        let typ = Self::plural(&());
+        let format = format!("format is {typ}/<name>");
+
+        let Some(name) = segments.first() else {
+            return Err(eyre!(format).wrap_err("name not provided"));
+        };
+
+        let path = segments.join("/");
+
+        if !access(
+            client.clone(),
+            ResourceAttributes {
+                resource: Some(format!("{typ}/proxy")),
+                verb: Some("create".to_string()),
+                name: Some((*name).to_string()),
+                ..Default::default()
+            },
+        )
+        .await?
+        {
+            return Err(eyre!("grant `create` for `{typ}/proxy`")
+                .wrap_err(format!("proxy for {path} is forbidden.")));
+        }
+
+        match Api::<Node>::all(client).get_opt(name).await {
+            Ok(Some(node)) => Ok(node
+                .status
+                .ok_or(eyre!("{path} missing status"))?
+                .addresses
+                .ok_or(eyre!("{path} missing addresses"))?
+                .iter()
+                .find(|a| a.type_ == "InternalIP")
+                .ok_or(eyre!("{path} missing internal ip"))?
+                .address
+                .clone()),
+            Ok(None) => Err(eyre!("{path} not found")),
+            Err(kube::Error::Api(ErrorResponse { code: 403, .. })) => {
+                Err(eyre!("grant `get` for `{typ}` to proxy")
+                    .wrap_err(format!("get forbidden for {path}")))
+            }
+            Err(kube::Error::Api(e)) => {
+                Err(eyre!(e.message).wrap_err(format!("failed getting {typ}")))
+            }
+            Err(e) => Err(eyre!(e).wrap_err(format!("failed getting {typ}"))),
+        }
+    }
+}

--- a/src/widget/error.rs
+++ b/src/widget/error.rs
@@ -1,3 +1,4 @@
+use ansi_to_tui::IntoText;
 use eyre::{Report, Result};
 use ratatui::{
     layout::Rect,
@@ -10,17 +11,27 @@ use ratatui::{
 use super::Widget;
 use crate::events::{Broadcast, Event, Keypress};
 
+#[derive(Default)]
 pub struct Error {
-    inner: Report,
+    msg: String,
 
     position: (u16, u16),
 }
 
-impl Error {
-    pub fn new(inner: Report) -> Self {
+impl From<Report> for Error {
+    fn from(err: Report) -> Self {
         Self {
-            inner,
-            position: (0, 0),
+            msg: format!("Error:{err:?}"),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<String> for Error {
+    fn from(msg: String) -> Self {
+        Self {
+            msg,
+            ..Default::default()
         }
     }
 }
@@ -52,7 +63,7 @@ impl Widget for Error {
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Red));
 
-        let pg = Paragraph::new(format!("Error:{:?}", self.inner))
+        let pg = Paragraph::new(self.msg.as_bytes().into_text()?)
             .block(block)
             .scroll(self.position);
 

--- a/src/widget/log.rs
+++ b/src/widget/log.rs
@@ -190,7 +190,7 @@ fn log_stream<'a>(
         {
             Ok(stream) => stream.lines(),
             Err(err) => {
-                let kube::Error::Api(resp) = err else {
+                let kube::Error::Api(resp) = &err else {
                     return Err(Report::new(err));
                 };
 
@@ -202,15 +202,15 @@ fn log_stream<'a>(
                     return log_stream(client, pod, tx, new_params).await;
                 }
 
-                tracing::info!("resp: {:#?}", resp);
-
-                return Err(eyre!("fart"));
+                return Err(eyre!(err));
             }
         };
 
         while let Some(line) = stream.try_next().await? {
             tx.send(line)?;
         }
+
+        tracing::info!("stream ended");
 
         Ok(())
     }

--- a/src/widget/table.rs
+++ b/src/widget/table.rs
@@ -272,7 +272,7 @@ impl Table {
         match widget.dispatch(event) {
             Ok(result) => Ok(result),
             Err(err) => {
-                self.state.detail(Box::new(Error::new(err)));
+                self.state.detail(Box::new(Error::from(err)));
 
                 Ok(Broadcast::Consumed)
             }

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -132,7 +132,7 @@ impl Widget for TabbedView {
             .areas(body_area);
 
         if let Err(err) = self.current.draw(frame, nested) {
-            self.current = Box::new(Error::new(err));
+            self.current = Box::new(Error::from(err));
         }
 
         Ok(())


### PR DESCRIPTION
- To get this working correctly, the data and state management in `session` needed to be refactored. This is because tcpip requests create new channels on top of the initial one used via pty requests. Now the state stops at `Authenticated` and the functions themselves hold their own state (like russh_sftp taking ownership of the channel).
- Error handling is a little tricky, there's no way to return an error on the incoming tcpip channel (no idea what the protocol is after all). So, it is possible to broadcast to a `writer` from anywhere in the session. In the case of the dashboard, this results in an error that pops up for the user.
- Ratatui can't handle ANSI, so now the `color_eyre` output is correctly converted into a `Text` widget.
- The dashboard now takes an `impl AsyncRead` along with the `impl Writer` that it used to. This required changing the `stdin` reader in the dashboard dev command.
- `channel_eof` now correctly only closes the channel it was meant for and not the entire session (especially if a dashboard was running).
- As data is now owned by the request that created it, the session level data handler only tracks total bytes.