### PR TITLE
feat(network): add egress tunneling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,6 +2009,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "lazy_static",
+ "local-ip-address",
  "mio 1.0.2",
  "pkcs8",
  "prometheus",
@@ -2027,6 +2028,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_yaml",
  "ssh-key",
+ "strum",
  "strum_macros",
  "syntect",
  "syntect-tui",
@@ -2088,6 +2090,18 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "local-ip-address"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b435d7dd476416a905f9634dff8c330cee8d3168fdd1fbd472a17d1a75c00c3e"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "lock_api"
@@ -2236,6 +2250,31 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "neli"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ jsonwebtoken = "9.3.0"
 k8s-openapi = { version = "0.22.0", features = ["earliest"] }
 kube = { version = "0.93.1", features = ["derive", "runtime", "ws"] }
 lazy_static = "1.5.0"
+local-ip-address = "0.6.2"
 mio = "1.0.2"
 pkcs8 = "0.10.2"
 prometheus = "0.13.4"
@@ -67,6 +68,7 @@ serde_json = "1.0.127"
 serde_path_to_error = "0.1.16"
 serde_yaml = "0.9.34"
 ssh-key = "0.6.6"
+strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
 syntect = "5.2.0"
 syntect-tui = "3.0.3"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,7 +42,7 @@ be available to run inside the cluster.
 
 [k3d]: https://k3d.io/v5.6.3/#releases
 
-## Forwarding
+## Ingress Tunnel
 
 If testing port forwarding and running the service locally (aka not on the
 cluster), you won't have access to any of the DNS or IP addresses that might be
@@ -60,3 +60,14 @@ ssh -L 9090:svc/default/localhost:9091 me@localhost -p 2222
 
 Testing `pods` and `nodes` requires running on the cluster as the response from
 `addr` for those is IP addresses.
+
+## Egress Tunnel
+
+If you're not running on the cluster, you'll want to:
+
+- Make sure you're running from the same network (doable with some games with
+  VPNs and local clusters).
+- Set `HOSTNAME` to a pod in the cluster that is in your default namespace.
+- Set `POD_UID` to the `metadata.uid` of the pod from `HOSTNAME`.
+- Set `POD_IP` to the IP address of your host. You can get this by going into a
+  pod and doing a `nslookup host.docker.internal`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ You can:
 - Access the logs for running and exited containers in a pod.
 - Forward a local port remotely, allowing access to services and pods in the
   cluster.
-  - `scp` files from pods. sftp clients work as well.
+- Forward a remote service to your local system.
+- `scp` files from pods. sftp clients work as well.
 
 ![demo](./assets/demo.gif)
 
@@ -77,7 +78,7 @@ ssh anything@my-remote-host-or-ip -p 2222
 The provided username is not used as your identity is authenticated via other
 mechanisms.
 
-### Port Forward
+### Ingress Tunnel (`ssh -L`)
 
 You can forward requests from a local port into a resource on the remote
 cluster. The supported resources are `nodes`, `pods` and `services`. See the
@@ -107,6 +108,19 @@ With that running in one terminal, you can run this in another:
 ```bash
 ssh my-node-username@localhost -p 3333
 ```
+
+### Egress Tunnel (`ssh -R`)
+
+You can forward a remote service on your cluster to a port on your local host.
+
+To forward port 8080 on service `default/kuberift` to port `9090` on your local
+system, you can run:
+
+```bash
+ssh me@my-cluster -p 2222 -R default/kuberift:8080:localhost:9090
+```
+
+The format for service definitions is `<namespace>/<service-name>`.
 
 ### SFTP
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,10 @@
 # TODO
 
+## Documentation
+
+- Get a full architecture explanation together.
+- Explain "how it works" for each piece of functionality.
+
 ## Authorization
 
 - Groups are probably what most users are going to want to use to configure all
@@ -49,6 +54,14 @@
 - Enable `ssh -L` for forwarding requests _into_ a pod.
 - Enable `ssh -R` for forwarding a remote service _into_ a localhost.
 
-## TCP/IP Forwarding
+## Ingress Tunnel
 
-- Implement `-R` for proxying from the cluster to localhost.
+## Egress Tunnel
+
+- Display error for when the `tcpip_forward` address is `localhost`.
+- Need some way to do cleanup and lifecycle management of endpoints and
+  services.
+
+## Build
+
+- Move client_id and config_url to a build-time concern.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -45,7 +45,7 @@ kubectl create clusterrolebinding foo-bar-com --clusterrole=<my-role> --user=foo
 Note that you can use a `RoleBinding` instead, but only for specific
 functionality.
 
-### SSH RBAC
+### SSH
 
 The minimum permissions are:
 
@@ -71,7 +71,7 @@ verbs: ['create']
 Note: without the full permissions it is possible that the dashboard has some
 issues rendering.
 
-### Port Forwarding RBAC
+### Ingress Tunnel (`ssh -L`)
 
 For each supported resource type (nodes, services, pods), you need:
 
@@ -106,7 +106,16 @@ rules:
       - get
 ```
 
-### SFTP(SCP) RBAC
+### Egress Tunnel (`ssh -L`)
+
+The minimum permissions are:
+
+```yaml
+resources: ['services', 'endpointslices']
+verbs: ['patch']
+```
+
+### SFTP(SCP)
 
 To support `scp`, the minimum permissions are:
 

--- a/helm/templates/server.yaml
+++ b/helm/templates/server.yaml
@@ -96,6 +96,10 @@ spec:
               value: {{ .clientID }}
             - name: KUBERIFT_OID_CONFIG_URL
               value: {{ .configURL }}
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           {{- end }}
 
           {{- if .resources}}

--- a/src/cli/users.rs
+++ b/src/cli/users.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 use crate::{
     identity::{key, Identity},
     resources::KubeID,
-    ssh::{Authenticate, Controller},
+    ssh::{Authenticate, ControllerBuilder},
 };
 
 #[derive(Parser, Container)]
@@ -49,7 +49,9 @@ impl Command for Check {
     async fn run(&self) -> Result<()> {
         let identity = Identity::new(self.id.clone(), self.groups.clone());
 
-        let ctrl = Controller::new(kube::Config::infer().await?);
+        let ctrl = ControllerBuilder::default()
+            .config(kube::Config::infer().await?)
+            .build()?;
 
         if identity.authenticate(&ctrl).await?.is_some() {
             println!("{identity} has access");

--- a/src/openid.rs
+++ b/src/openid.rs
@@ -180,7 +180,7 @@ impl Provider {
 
         // TODO: add groups via claim to the identity.
         Ok((
-            Identity::new(name.as_str().unwrap().into(), Vec::new()),
+            Identity::new(name.as_str().unwrap().into(), Vec::new()).method("openid".into()),
             chrono::Utc::now() + oauth_token.expires_in,
         ))
     }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -3,7 +3,7 @@ pub mod container;
 pub mod file;
 pub mod pod;
 pub mod store;
-pub mod stream;
+pub mod tunnel;
 
 use color_eyre::Section;
 use eyre::{eyre, Result};

--- a/src/resources/tunnel.rs
+++ b/src/resources/tunnel.rs
@@ -1,0 +1,138 @@
+mod egress;
+mod ingress;
+
+use std::pin::Pin;
+
+use chrono::Utc;
+pub use egress::Egress;
+use eyre::Result;
+use futures::{future::join_all, Future};
+pub use ingress::Ingress;
+use lazy_static::lazy_static;
+use prometheus::{
+    histogram_opts, opts, register_histogram_vec, register_int_counter_vec, register_int_gauge_vec,
+    HistogramVec, IntCounterVec, IntGaugeVec,
+};
+use prometheus_static_metric::make_static_metric;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+make_static_metric! {
+    pub struct ResourceVec: IntCounter {
+        "resource" => {
+            pod,
+            service,
+            node,
+        },
+        "direction" => {
+            ingress,
+            egress,
+        }
+    }
+    pub struct ResourceGaugeVec: IntGauge {
+        "resource" => {
+            pod,
+            service,
+            node,
+        },
+        "direction" => {
+            ingress,
+            egress,
+        }
+    }
+}
+
+lazy_static! {
+    static ref STREAM_DURATION: HistogramVec = register_histogram_vec!(
+        histogram_opts!(
+            "stream_duration_seconds",
+            "Stream duration",
+            vec!(0.1, 0.2, 0.3, 0.5, 0.8, 1.3, 2.1),
+        ),
+        &["resource", "direction"]
+    )
+    .unwrap();
+    static ref STREAM_BYTES: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "stream_bytes_total",
+            "Total number of bytes streamed by resource and direction"
+        ),
+        &["resource", "direction", "destination"]
+    )
+    .unwrap();
+    static ref STREAM_TOTAL_VEC: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "stream_total",
+            "Total number of streams by resource and direction"
+        ),
+        &["resource", "direction"]
+    )
+    .unwrap();
+    static ref STREAM_TOTAL: ResourceVec = ResourceVec::from(&STREAM_TOTAL_VEC);
+    static ref STREAM_ACTIVE_VEC: IntGaugeVec = register_int_gauge_vec!(
+        opts!(
+            "stream_active",
+            "Number of active streams by resource and direction"
+        ),
+        &["resource", "direction"]
+    )
+    .unwrap();
+    static ref STREAM_ACTIVE: ResourceGaugeVec = ResourceGaugeVec::from(&STREAM_ACTIVE_VEC);
+}
+
+struct StreamMetrics<'a> {
+    resource: &'a str,
+    direction: &'a str,
+}
+
+impl StreamMetrics<'_> {
+    fn values(&self) -> [&str; 2] {
+        [self.resource, self.direction]
+    }
+}
+
+async fn stream(
+    src: (impl AsyncRead + Send, impl AsyncWrite + Send),
+    dst: (impl AsyncRead + Send, impl AsyncWrite + Send),
+    meta: StreamMetrics<'_>,
+) -> Result<()> {
+    STREAM_TOTAL_VEC.with_label_values(&meta.values()).inc();
+    STREAM_ACTIVE_VEC.with_label_values(&meta.values()).inc();
+
+    let start = Utc::now();
+
+    let src_read = src.0;
+    let src_write = src.1;
+    tokio::pin!(src_read);
+    tokio::pin!(src_write);
+
+    let dst_read = dst.0;
+    let dst_write = dst.1;
+    tokio::pin!(dst_read);
+    tokio::pin!(dst_write);
+
+    let mut bytes = join_all::<Vec<Pin<Box<dyn Future<Output = _> + Send>>>>(vec![
+        Box::pin(tokio::io::copy(&mut src_read, &mut dst_write)),
+        Box::pin(tokio::io::copy(&mut dst_read, &mut src_write)),
+    ])
+    .await;
+
+    STREAM_ACTIVE_VEC.with_label_values(&meta.values()).dec();
+    STREAM_DURATION.with_label_values(&meta.values()).observe(
+        (Utc::now() - start)
+            .to_std()
+            .expect("duration in range")
+            .as_secs_f64(),
+    );
+
+    let outgoing = bytes.pop().expect("outgoing bytes")?;
+    let incoming = bytes.pop().expect("incoming bytes")?;
+
+    STREAM_BYTES
+        .with_label_values(&[meta.resource, meta.direction, "incoming"])
+        .inc_by(incoming);
+    STREAM_BYTES
+        .with_label_values(&[meta.resource, meta.direction, "outgoing"])
+        .inc_by(outgoing);
+
+    Ok(())
+}

--- a/src/resources/tunnel/egress.rs
+++ b/src/resources/tunnel/egress.rs
@@ -1,0 +1,223 @@
+use std::collections::BTreeMap;
+
+use eyre::{eyre, Result};
+use k8s_openapi::{
+    api::{
+        core::v1::{Pod, Service, ServicePort, ServiceSpec},
+        discovery::v1::{Endpoint, EndpointConditions, EndpointPort, EndpointSlice},
+    },
+    apimachinery::pkg::util::intstr::IntOrString,
+};
+use kube::{
+    api::{ObjectMeta, Patch, PatchParams},
+    Api, Resource, ResourceExt,
+};
+use russh::server;
+use tokio::{net::TcpListener, task::JoinSet};
+
+use super::{stream, StreamMetrics};
+use crate::{
+    identity::Identity,
+    resources::{pod::PodExt, MANAGER},
+};
+
+static HOST_LABEL: &str = "egress.kuberift.com/host";
+static IDENTITY_LABEL: &str = "egress.kuberift.com/identity";
+
+pub struct Egress {
+    metadata: ObjectMeta,
+    port: u16,
+    tasks: JoinSet<Result<()>>,
+    current_pod: Pod,
+}
+
+impl Egress {
+    pub fn new(identity: &Identity, current_pod: Pod, service: &str, port: u16) -> Result<Self> {
+        let (ns, name) = service
+            .split_once('/')
+            .ok_or_else(|| eyre!("format is <namespace>/<name>"))?;
+
+        Ok(Self {
+            metadata: ObjectMeta {
+                name: Some(name.into()),
+                namespace: Some(ns.into()),
+                annotations: Some(BTreeMap::from([
+                    (HOST_LABEL.to_string(), current_pod.name_any()),
+                    (IDENTITY_LABEL.to_string(), identity.name.clone()),
+                ])),
+                ..Default::default()
+            },
+            port,
+            tasks: JoinSet::new(),
+            current_pod,
+        })
+    }
+
+    fn namespace(&self) -> Option<String> {
+        self.metadata.namespace.clone()
+    }
+
+    fn name_any(&self) -> String {
+        self.metadata.name.clone().expect("name is required")
+    }
+
+    fn path(&self) -> String {
+        format!(
+            "{}/{}",
+            self.namespace().unwrap_or_default(),
+            self.name_any()
+        )
+    }
+
+    // The assumption here is that the current hostname is the same as the pod name
+    // and that this is running inside a k8s cluster. This allows us to setup a
+    // selector that is only this pod because we add a label to the pod on startup.
+    #[allow(clippy::cast_lossless)]
+    async fn service(&self, client: kube::Client, local_port: u16) -> Result<Service> {
+        Api::<Service>::namespaced(
+            client,
+            self.namespace().expect("namespace is required").as_str(),
+        )
+        .patch(
+            &self.name_any(),
+            &PatchParams::apply(MANAGER).force(),
+            &Patch::Apply(&Service {
+                metadata: self.metadata.clone(),
+                spec: Some(ServiceSpec {
+                    ports: Some(vec![ServicePort {
+                        port: self.port as i32,
+                        target_port: Some(IntOrString::Int(local_port as i32)),
+                        ..Default::default()
+                    }]),
+                    selector: None,
+                    type_: Some("ClusterIP".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .map_err(|e| match e {
+            kube::Error::Api(e) => {
+                eyre!(e.message).wrap_err(format!("failed to update {}", self.path()))
+            }
+            e => e.into(),
+        })
+    }
+
+    async fn endpoint(&self, client: kube::Client, local_port: u16) -> Result<EndpointSlice> {
+        let addr = self
+            .current_pod
+            .ip()
+            .expect("current pod has an IP address");
+        let address_type = if addr.is_ipv4() { "IPv4" } else { "IPv6" };
+
+        let mut metadata = self.metadata.clone();
+        metadata.labels.get_or_insert(BTreeMap::new()).extend([
+            (
+                "endpointslice.kubernetes.io/managed-by".to_string(),
+                "egress.kuberift.com".to_string(),
+            ),
+            ("kubernetes.io/service-name".to_string(), self.name_any()),
+        ]);
+        metadata
+            .owner_references
+            .get_or_insert(Vec::new())
+            .push(self.current_pod.owner_ref(&()).expect("pods can be owners"));
+
+        #[allow(clippy::cast_lossless)]
+        let endpoint = EndpointSlice {
+            metadata,
+            address_type: address_type.to_string(),
+            endpoints: vec![Endpoint {
+                addresses: vec![addr.to_string()],
+                target_ref: Some(self.current_pod.object_ref(&())),
+                conditions: Some(EndpointConditions {
+                    ready: Some(true),
+                    serving: Some(true),
+                    terminating: Some(false),
+                }),
+                ..Default::default()
+            }],
+            ports: Some(vec![EndpointPort {
+                port: Some(local_port as i32),
+                ..Default::default()
+            }]),
+        };
+
+        Api::<EndpointSlice>::namespaced(
+            client,
+            self.namespace().expect("namespace is required").as_str(),
+        )
+        .patch(
+            &self.name_any(),
+            &PatchParams::apply(MANAGER).force(),
+            &Patch::Apply(&endpoint),
+        )
+        .await
+        .map_err(|e| match e {
+            kube::Error::Api(e) => {
+                eyre!(e.message).wrap_err(format!("failed to update endpoint for {}", self.path()))
+            }
+            e => e.into(),
+        })
+    }
+
+    pub async fn run(&mut self, client: kube::Client, handle: server::Handle) -> Result<()> {
+        tracing::debug!(
+            resource = "service",
+            direction = "egress",
+            activity = "tunnel::egress",
+            "connection",
+        );
+
+        let listener = TcpListener::bind("0.0.0.0:0").await?;
+        let local_port = listener.local_addr()?.port();
+
+        self.service(client.clone(), local_port).await?;
+        self.endpoint(client.clone(), local_port).await?;
+
+        loop {
+            let (socket, addr) = listener.accept().await?;
+            let handle = handle.clone();
+            let mut channel = handle
+                .channel_open_forwarded_tcpip(
+                    self.path(),
+                    u32::from(self.port),
+                    addr.ip().to_string(),
+                    u32::from(addr.port()),
+                )
+                .await?;
+            let id = channel.id();
+
+            self.tasks.spawn(async move {
+                let (src_read, src_write) = socket.into_split();
+                let dst_write = channel.make_writer();
+                let dst_read = channel.make_reader();
+
+                let result = stream(
+                    (src_read, src_write),
+                    (dst_read, dst_write),
+                    StreamMetrics {
+                        resource: "service",
+                        direction: "egress",
+                    },
+                )
+                .await;
+
+                handle
+                    .close(id)
+                    .await
+                    .map_err(|()| eyre!("failed to close channel {id}"))?;
+
+                result
+            });
+        }
+    }
+}
+
+impl Drop for Egress {
+    fn drop(&mut self) {
+        self.tasks.abort_all();
+    }
+}

--- a/src/ssh/session/state.rs
+++ b/src/ssh/session/state.rs
@@ -15,20 +15,12 @@ pub enum State {
     // states that get moved between, it feels like this should stop at authenticated and then let
     // each individual request track its own state. This'll require some extra work on the channel
     // side of things.
-    Authenticated(DebugClient, String),
+    Authenticated(Identity),
 }
 
-pub struct DebugClient(pub kube::Client);
-
-impl std::fmt::Debug for DebugClient {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "kube::Client")
-    }
-}
-
-impl AsRef<kube::Client> for DebugClient {
-    fn as_ref(&self) -> &kube::Client {
-        &self.0
+impl Default for State {
+    fn default() -> Self {
+        Self::Unauthenticated
     }
 }
 
@@ -73,7 +65,7 @@ impl State {
         *self = State::InvalidIdentity(identity, key);
     }
 
-    pub fn authenticated(&mut self, client: kube::Client, method: String) {
-        *self = State::Authenticated(DebugClient(client), method);
+    pub fn authenticated(&mut self, identity: Identity) {
+        *self = State::Authenticated(identity);
     }
 }


### PR DESCRIPTION
- Enabled `ssh -R` for tunneling from the cluster to the local host. This introduces a bunch of weirdness around "how does the cluster contact the server".
- Moved `stream` to `tunnel` and `direct` to `ingress`. This is closer to what it is actually doing, especially because I didn't understand the difference between direct/forward/tcpip.
- Added feature flags. Now, what features are enabled can be configured at runtime. This allows any incoming requests to be short-circuited if they'd never work or shouldn't be supported.
- Made `Authenticate` return an identity (that has been authenticated) instead of a client. It is weird to have `Identity::authenticate` return an identity, but it makes more sense for `Key`.
- Moved `Identity` into `State::Authenticated`. This was primarily to get the user's identity on the created `Egress` tunnel but likely makes more sense anyways as you end up creating a new client all the time as it is. Unfortunately, the `Controller` is still required to create that client - they can't be minted fresh from an Identity.