### PR TITLE
feat: automating brew tap

### DIFF
--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -1,0 +1,33 @@
+name: homebrew-releaser
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  homebrew-releaser:
+    runs-on: ubuntu-latest
+    name: homebrew-releaser
+    steps:
+      - name: publish tap
+        uses: Justintime50/homebrew-releaser@v1
+        with:
+          homebrew_owner: grampelberg
+          homebrew_tap: homebrew-kty
+          github_token: ${{ secrets.BREW_TOKEN }}
+
+          commit_owner: Thomas Rampelberg
+          commit_email: thomas@saunter.org
+
+          install: 'bin.install "kty" => "kty"'
+          test: 'assert_match("kty", shell_output("kty"))'
+
+          target_darwin_amd64: false
+          target_darwin_arm64: true
+          target_linux_amd64: true
+          target_linux_arm64: true
+
+          update_readme_table: true
+          skip_commit: false
+
+          debug: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,11 +51,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: |
-          just set-version build-binary
-
-      - name: rename
-        run: |-
-          cp target/release/kty kty-${{ matrix.os }}-${{ matrix.arch }}
+          just set-version build-binary tar-bin ${{ matrix.os }} ${{ matrix.arch }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Automate the process of publishing a Homebrew tap by adding a GitHub Actions workflow that triggers on pull requests to the main branch and on release events. The workflow uses the Justintime50/homebrew-releaser action to handle the tap publication.

CI:
- Add a GitHub Actions workflow to automate the publishing of a Homebrew tap using the Justintime50/homebrew-releaser action.

<!-- Generated by sourcery-ai[bot]: end summary -->