### PR TITLE
chore(build): use gha cache for PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,8 +70,10 @@ jobs:
           file: docker/kty.dockerfile
           platforms: ${{ inputs.os }}/${{ inputs.arch }}
 
-          cache-from: type=registry,ref=${{ env.CACHE }}
-          cache-to: type=registry,ref=${{ env.CACHE }},mode=max
+          cache-from: |
+            ${{ inputs.arch == 'arm64' && format('type=registry,ref={0}', env.CACHE) || 'type=gha' }}
+          cache-to: |
+            ${{ inputs.arch == 'arm64' && format('type=registry,ref={0},mode=max', env.CACHE) || 'type=gha' }}
 
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/TODO.md
+++ b/TODO.md
@@ -39,7 +39,14 @@
 
 ## TUI
 
+- There needs to be some way to pre-flight permissions for a component so that
+  an error is shown instead of letting the component fail.
+
 - Is it possible to get the kubelet logs?
+
+  - `kubectl get --raw "/api/v1/nodes/node-1.example/proxy/logs/` works as
+    `NodeQueryLog` which is beta in 1.30. It is a little weird though, k3s at
+    least returns html? And it doesn't contain the kubelet logs?
 
 - Use SSH forwarding to get into the nodes.
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Use GitHub Actions cache for pull requests in the GitHub Actions workflow, optimizing caching strategy for non-arm64 architectures.

Build:
- Update the GitHub Actions workflow to use GitHub Actions cache for pull requests instead of registry cache for non-arm64 architectures.

<!-- Generated by sourcery-ai[bot]: end summary -->